### PR TITLE
fix(declaration-converters-mapping): fix border shorthands, improves border-width, and fixes border arbitrary values

### DIFF
--- a/src/mappings/declaration-converters-mapping.ts
+++ b/src/mappings/declaration-converters-mapping.ts
@@ -108,8 +108,40 @@ function convertBorderDeclarationValue(
   config: ResolvedTailwindConverterConfig,
   classPrefix: string
 ) {
-  const [width, style, ...colorArray] = value.split(/\s+/m);
-  const color = colorArray.join(' ');
+  const tokens = value.trim().split(/\s+/m);
+  let width = '';
+  let style = '';
+  let color = '';
+
+  const borderStyles = new Set([
+    'none',
+    'hidden',
+    'dotted',
+    'dashed',
+    'solid',
+    'double',
+    'groove',
+    'ridge',
+    'inset',
+    'outset',
+  ]);
+
+  function isLength(value: string): boolean {
+    return (
+      /^[-+]?\d*\.?\d+(px|em|rem|ch|vw|vh|%)?$/.test(value) ||
+      ['thin', 'medium', 'thick'].includes(value)
+    );
+  }
+
+  for (const token of tokens) {
+    if (borderStyles.has(token)) {
+      style = token;
+    } else if (isLength(token)) {
+      width = token;
+    } else {
+      color += (color ? ' ' : '') + token;
+    }
+  }
 
   let classes: string[] = [];
 

--- a/src/mappings/declaration-converters-mapping.ts
+++ b/src/mappings/declaration-converters-mapping.ts
@@ -128,7 +128,7 @@ function convertBorderDeclarationValue(
 
   function isLength(value: string): boolean {
     return (
-      /^[-+]?\d*\.?\d+(px|em|rem|ch|vw|vh|%)?$/.test(value) ||
+      /^[-+]?\d*\.?\d*(px|em|rem|ch|vw|vh|%)?$|^0$/.test(value) ||
       ['thin', 'medium', 'thick'].includes(value)
     );
   }

--- a/test/TailwindConverter.spec.ts
+++ b/test/TailwindConverter.spec.ts
@@ -580,4 +580,22 @@ describe('TailwindConverter', () => {
       },
     ]);
   });
+
+  it('should convert border with color function correctly even if width is missing', async () => {
+    const converter = createTailwindConverter();
+    const css = `
+      td {
+        border: solid rgba(148, 163, 184, 0.1);
+      }
+    `;
+    const converted = await converter.convertCSS(css);
+
+    expect(converted.convertedRoot.toString()).toMatchSnapshot();
+    expect(converted.nodes).toEqual([
+      {
+        rule: expect.objectContaining({ selector: 'td' }),
+        tailwindClasses: ['border-solid', 'border-[rgba(148,163,184,0.1)]'],
+      },
+    ]);
+  });
 });

--- a/test/TailwindConverter.spec.ts
+++ b/test/TailwindConverter.spec.ts
@@ -587,7 +587,12 @@ describe('TailwindConverter', () => {
       td {
         border: solid rgba(148, 163, 184, 0.1);
       }
-    `;
+      .a {
+        border: rgba(148, 163, 184, 0.1) 0 dotted;
+      }
+      .b {
+        border: rgba(148, 163, 184, 0.1);
+      }`;
     const converted = await converter.convertCSS(css);
 
     expect(converted.convertedRoot.toString()).toMatchSnapshot();
@@ -595,6 +600,18 @@ describe('TailwindConverter', () => {
       {
         rule: expect.objectContaining({ selector: 'td' }),
         tailwindClasses: ['border-solid', 'border-[rgba(148,163,184,0.1)]'],
+      },
+      {
+        rule: expect.objectContaining({ selector: '.a' }),
+        tailwindClasses: [
+          'border-0',
+          'border-dotted',
+          'border-[rgba(148,163,184,0.1)]',
+        ],
+      },
+      {
+        rule: expect.objectContaining({ selector: '.b' }),
+        tailwindClasses: ['border-[rgba(148,163,184,0.1)]'],
       },
     ]);
   });

--- a/test/TailwindConverter.spec.ts
+++ b/test/TailwindConverter.spec.ts
@@ -644,6 +644,10 @@ describe('TailwindConverter', () => {
       }
       .g {
         border: 4.5em solid;
+      }
+      .h {
+        border-color: rgba(148, 163, 184, 0.1);
+        border-width: 1px 2px 1px 2px;
       }`;
     const converted = await converter.convertCSS(css);
 
@@ -698,6 +702,14 @@ describe('TailwindConverter', () => {
       {
         rule: expect.objectContaining({ selector: '.g' }),
         tailwindClasses: ['border-w-[4.5em]', 'border-solid'],
+      },
+      {
+        rule: expect.objectContaining({ selector: '.h' }),
+        tailwindClasses: [
+          'border-x-2',
+          'border-[rgba(148,163,184,0.1)]',
+          'border-y',
+        ],
       },
     ]);
   });

--- a/test/TailwindConverter.spec.ts
+++ b/test/TailwindConverter.spec.ts
@@ -581,7 +581,7 @@ describe('TailwindConverter', () => {
     ]);
   });
 
-  it('should convert border with color function correctly even if width is missing', async () => {
+  it('should convert border with color correctly even if width is missing', async () => {
     const converter = createTailwindConverter();
     const css = `
       td {
@@ -612,6 +612,92 @@ describe('TailwindConverter', () => {
       {
         rule: expect.objectContaining({ selector: '.b' }),
         tailwindClasses: ['border-[rgba(148,163,184,0.1)]'],
+      },
+    ]);
+  });
+
+  it('should convert border width on shorthand correctly', async () => {
+    const converter = createTailwindConverter();
+    const css = `
+      td {
+        border: 1px solid rgba(148, 163, 184, 0.1);
+      }
+      .a {
+        border-color: rgba(148, 163, 184, 0.1);
+        border-width: 1px 2px;
+      }
+      .b {
+        border-color: rgba(148, 163, 184, 0.1);
+        border-width: 2px;
+      }
+      .c {
+        border-color: rgba(148, 163, 184, 0.1);
+        border-width: 1px 0px 3px;
+      }
+      .d {
+        border-color: rgba(148, 163, 184, 0.1);
+        border-width: 1px 0px 2px;
+      }
+      .f {
+        border-color: rgba(148, 163, 184, 0.1);
+        border-width: 1px 3px 2px 4.5em;
+      }
+      .g {
+        border: 4.5em solid;
+      }`;
+    const converted = await converter.convertCSS(css);
+
+    expect(converted.convertedRoot.toString()).toMatchSnapshot();
+    expect(converted.nodes).toEqual([
+      {
+        rule: expect.objectContaining({ selector: 'td' }),
+        tailwindClasses: [
+          'border',
+          'border-solid',
+          'border-[rgba(148,163,184,0.1)]',
+        ],
+      },
+      {
+        rule: expect.objectContaining({ selector: '.a' }),
+        tailwindClasses: [
+          'border-x-2',
+          'border-[rgba(148,163,184,0.1)]',
+          'border-y',
+        ],
+      },
+      {
+        rule: expect.objectContaining({ selector: '.b' }),
+        tailwindClasses: ['border-[rgba(148,163,184,0.1)]', 'border-2'],
+      },
+      {
+        rule: expect.objectContaining({ selector: '.c' }),
+        tailwindClasses: [
+          'border-b-[3px]',
+          'border-[rgba(148,163,184,0.1)]',
+          'border-t',
+        ],
+      },
+      {
+        rule: expect.objectContaining({ selector: '.d' }),
+        tailwindClasses: [
+          'border-b-2',
+          'border-[rgba(148,163,184,0.1)]',
+          'border-t',
+        ],
+      },
+      {
+        rule: expect.objectContaining({ selector: '.f' }),
+        tailwindClasses: [
+          'border-l-[4.5em]',
+          'border-r-[3px]',
+          'border-b-2',
+          'border-[rgba(148,163,184,0.1)]',
+          'border-t',
+        ],
+      },
+      {
+        rule: expect.objectContaining({ selector: '.g' }),
+        tailwindClasses: ['border-w-[4.5em]', 'border-solid'],
       },
     ]);
   });

--- a/test/__snapshots__/TailwindConverter.spec.ts.snap
+++ b/test/__snapshots__/TailwindConverter.spec.ts.snap
@@ -18,7 +18,31 @@ exports[`TailwindConverter should consider \`prefix\`, \`separator\` and \`coreP
 "
 `;
 
-exports[`TailwindConverter should convert border with color function correctly even if width is missing 1`] = `
+exports[`TailwindConverter should convert border width on shorthand correctly 1`] = `
+"td {
+    @apply border border-solid border-[rgba(148,163,184,0.1)];
+}
+.a {
+    @apply border-x-2 border-[rgba(148,163,184,0.1)] border-y;
+}
+.b {
+    @apply border-[rgba(148,163,184,0.1)] border-2;
+}
+.c {
+    @apply border-b-[3px] border-[rgba(148,163,184,0.1)] border-t;
+}
+.d {
+    @apply border-b-2 border-[rgba(148,163,184,0.1)] border-t;
+}
+.f {
+    @apply border-l-[4.5em] border-r-[3px] border-b-2 border-[rgba(148,163,184,0.1)] border-t;
+}
+.g {
+    @apply border-w-[4.5em] border-solid;
+}"
+`;
+
+exports[`TailwindConverter should convert border with color correctly even if width is missing 1`] = `
 "td {
     @apply border-solid border-[rgba(148,163,184,0.1)];
 }

--- a/test/__snapshots__/TailwindConverter.spec.ts.snap
+++ b/test/__snapshots__/TailwindConverter.spec.ts.snap
@@ -18,6 +18,13 @@ exports[`TailwindConverter should consider \`prefix\`, \`separator\` and \`coreP
 "
 `;
 
+exports[`TailwindConverter should convert border with color function correctly even if width is missing 1`] = `
+"td {
+    @apply border-solid border-[rgba(148,163,184,0.1)];
+}
+    "
+`;
+
 exports[`TailwindConverter should convert the complex CSS 1`] = `
 "@charset \\"UTF-8\\";
 .foo{

--- a/test/__snapshots__/TailwindConverter.spec.ts.snap
+++ b/test/__snapshots__/TailwindConverter.spec.ts.snap
@@ -22,7 +22,12 @@ exports[`TailwindConverter should convert border with color function correctly e
 "td {
     @apply border-solid border-[rgba(148,163,184,0.1)];
 }
-    "
+.a {
+    @apply border-0 border-dotted border-[rgba(148,163,184,0.1)];
+}
+.b {
+    @apply border-[rgba(148,163,184,0.1)];
+}"
 `;
 
 exports[`TailwindConverter should convert the complex CSS 1`] = `

--- a/test/__snapshots__/TailwindConverter.spec.ts.snap
+++ b/test/__snapshots__/TailwindConverter.spec.ts.snap
@@ -39,6 +39,9 @@ exports[`TailwindConverter should convert border width on shorthand correctly 1`
 }
 .g {
     @apply border-w-[4.5em] border-solid;
+}
+.h {
+    @apply border-x-2 border-[rgba(148,163,184,0.1)] border-y;
 }"
 `;
 


### PR DESCRIPTION
Supports border shorthand when some of its values are missing (width, style, color)

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The way `border` shorthand was being converted, it was always expecting a perfect value, in order, and nothing missing: `width style color`. But sometimes `border` doesn't come with width, or style, or color - and it's still valid CSS. Or it could be on a completely different order, like `color width style`.

Example:
```
td {
  border: solid rgba(148, 163, 184, 0.1);
}
```

was converting to:
```
td {
  @apply border-[solid] border-[163,184,0.1)];
}
```

now converts to:
```
td {
  @apply border-[solid] border-[rgba(148,163,184,0.1)];
}
```

Fixes #26 

It now also properly handles border-width arbitrary value. It used to convert `border-width: 4.5em` to `border-[4.5em]` which is wrong (that is for border-color), now it converts to `border-w-[4.5em]` and it's quite smart and converts `border-width: 1px 2px;` to `border-y border-x-2`

Fixes +1:  #25
