### PR TITLE
fix: `from` option warning

### DIFF
--- a/src/TailwindConverter.ts
+++ b/src/TailwindConverter.ts
@@ -79,6 +79,7 @@ export class TailwindConverter {
   async convertCSS(css: string) {
     const nodesManager = new TailwindNodesManager();
     const parsed = await postcss(this.config.postCSSPlugins).process(css, {
+      from: undefined,
       parser: postcssSafeParser,
     });
 


### PR DESCRIPTION
Mutes the PostCSS warning about `from` not being set:

_Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning._